### PR TITLE
some comestic changes, but test_modify_user is still not OK

### DIFF
--- a/src/ucengine/__init__.py
+++ b/src/ucengine/__init__.py
@@ -6,4 +6,4 @@ __author__ = "mathieu@garambrogne.net"
 
 from ucengine.core import UCEngine, UCError
 from ucengine.meeting import Meeting, Meetings
-from ucengine.user import User
+from ucengine.user import User as UCUser

--- a/src/ucengine/__init__.py
+++ b/src/ucengine/__init__.py
@@ -4,6 +4,7 @@ Client for UCEngine
 
 __author__ = "mathieu@garambrogne.net"
 
-from uce import UCEngine, UCError
+from core import UCError
+from uce import UCEngine
 from user import UCUser
 from meeting import Meeting

--- a/src/ucengine/core.py
+++ b/src/ucengine/core.py
@@ -1,14 +1,10 @@
 __author__ = "mathieu@garambrogne.net"
 
-import json
-
 from gevent import monkey
 import gevent
 
 monkey.patch_all()
 
-import httplib
-import urllib
 
 class UCError(Exception):
     "Standard error coming from the server"
@@ -19,42 +15,6 @@ class UCError(Exception):
 
     def __repr__(self):
         return "<UCError:%i %s>" % (self.code, self.value)
-
-class UCEngine(object):
-    "The Server"
-    def __init__(self, host, port):
-        self.host = host
-        self.port = port
-        self.users = []
-
-    def request(self, method, path, body=None):
-        "ask something to the server"
-        connection = httplib.HTTPConnection(self.host, self.port)
-        if body != None:
-            connection.request(method, '/api/0.6%s' % path,
-                urllib.urlencode(body))
-        else:
-            connection.request(method, '/api/0.6%s' % path)
-        resp = connection.getresponse()
-        raw = resp.read()
-        try:
-            response = json.loads(raw)
-        except ValueError as e:
-            print raw
-            response = None
-        connection.close()
-        return resp.status, response
-
-    def connect(self, user, credential):
-        status, resp = self.request('POST', '/presence/', {
-            'name'               : user.name,
-            'credential'         : credential,
-            'metadata[nickname]' : user.name}
-            )
-        if status == 201:
-            return Session(self, resp['result']['uid'], resp['result']['sid'])
-        else:
-            raise UCError(status, resp)
 
 
 class Eventualy(object):

--- a/src/ucengine/session.py
+++ b/src/ucengine/session.py
@@ -126,7 +126,7 @@ class Session(Eventualy):
         us = []
         for u in resp['result']:
             us.append(
-                User(u['name'],
+                UCUser(u['name'],
                     metadata = u['metadata'],
                     uid = u['uid'])
             )

--- a/src/ucengine/uce.py
+++ b/src/ucengine/uce.py
@@ -2,8 +2,8 @@ import httplib
 import urllib
 import json
 
-from core import UCError
 from session import Session
+from core import UCError
 
 class UCEngine(object):
     "The Server"
@@ -38,5 +38,4 @@ class UCEngine(object):
             return Session(self, resp['result']['uid'], resp['result']['sid'])
         else:
             raise UCError(status, resp)
-
 

--- a/src/ucengine/user.py
+++ b/src/ucengine/user.py
@@ -7,10 +7,14 @@ import urllib
 
 class User(object):
     "A user"
-    def __init__(self, name):
+    def __init__(self, name, credential=None, uid=None, auth=None, metadata=None):
         self.name = name
+        self.credential = credential
+        self.uid = uid
+        self.auth = auth
         self.metadata = {'nickname' : name}
-        self.credential = None
-        self.uid = None
+        if metadata:
+            self.metadata.update(metadata)
+
     def __repr__(self):
         return "<User name:%s>" % self.name

--- a/src/ucengine/user.py
+++ b/src/ucengine/user.py
@@ -3,9 +3,8 @@ __author__ = "mathieu@garambrogne.net"
 from gevent import monkey
 monkey.patch_all()
 
-import urllib
 
-class User(object):
+class UCUser(object):
     "A user"
     def __init__(self, name, credential=None, uid=None, auth=None, metadata=None):
         self.name = name
@@ -17,4 +16,4 @@ class User(object):
             self.metadata.update(metadata)
 
     def __repr__(self):
-        return "<User name:%s>" % self.name
+        return "<UCUser name:%s>" % self.name

--- a/test/basic.py
+++ b/test/basic.py
@@ -1,16 +1,15 @@
 import sys
-import time
 import unittest
 import os.path
 sys.path.insert(1, os.path.abspath('src'))
-from ucengine import UCEngine, User
+from ucengine import UCEngine, UCUser, UCError
 
 class TestBasic(unittest.TestCase):
 
     def setUp(self):
-        self.uce = UCEngine('localhost', 5280)
+        self.uce = UCEngine('vps11240.ovh.net', 8052)
 
-        self.victor = User('participant')
+        self.victor = UCUser('participant')
         self.session = self.uce.connect(self.victor, 'pwd').loop()
 
     def tearDown(self):
@@ -20,7 +19,7 @@ class TestBasic(unittest.TestCase):
         self.assertTrue(None != self.session.sid)
 
     def test_bad_presence(self):
-        thierry = User('thierry')
+        thierry = UCUser('thierry')
         try:
             self.uce.connect(thierry, '****')
         except UCError as e:
@@ -36,15 +35,16 @@ class TestBasic(unittest.TestCase):
         self.assertEquals(u'localhost', infos['domain'])
 
     def test_modify_user(self):
-        owner = User('root')
+        owner = UCUser('root')
         session = self.uce.connect(owner, 'root')
         print session.users()
-        bob = User('Bob')
+        bob = UCUser('participant')
         bob.metadata['nickname'] = "Robert les grandes oreilles"
         session.save(bob)
+
     """
     def test_meeting(self):
-        thierry = User('participant2')
+        thierry = UCUser('participant2')
         sthierry = self.uce.connect(thierry, 'pwd')
         SESSION = 'demo'
         MSG = u"Bonjour monde"

--- a/test/basic.py
+++ b/test/basic.py
@@ -9,6 +9,7 @@ class TestBasic(unittest.TestCase):
 
     def setUp(self):
         self.uce = UCEngine('localhost', 5280)
+
         self.victor = User('participant')
         self.session = self.uce.connect(self.victor, 'pwd').loop()
 

--- a/test/basic.py
+++ b/test/basic.py
@@ -7,7 +7,8 @@ from ucengine import UCEngine, UCUser, UCError
 class TestBasic(unittest.TestCase):
 
     def setUp(self):
-        self.uce = UCEngine('localhost', 5280)
+        #self.uce = UCEngine('localhost', 5280)
+        self.uce = UCEngine('vps11240.ovh.net', 8052)
 
         self.victor = UCUser('participant')
         self.session = self.uce.connect(self.victor, 'pwd').loop()

--- a/test/basic.py
+++ b/test/basic.py
@@ -38,7 +38,7 @@ class TestBasic(unittest.TestCase):
         owner = UCUser('root')
         session = self.uce.connect(owner, 'root')
         print session.users()
-        bob = UCUser('participant')
+        bob = UCUser('Bob')
         bob.metadata['nickname'] = "Robert les grandes oreilles"
         session.save(bob)
 

--- a/test/basic.py
+++ b/test/basic.py
@@ -7,7 +7,7 @@ from ucengine import UCEngine, UCUser, UCError
 class TestBasic(unittest.TestCase):
 
     def setUp(self):
-        self.uce = UCEngine('vps11240.ovh.net', 8052)
+        self.uce = UCEngine('localhost', 5280)
 
         self.victor = UCUser('participant')
         self.session = self.uce.connect(self.victor, 'pwd').loop()


### PR DESCRIPTION
The changes are comestic, the point is test_modifiy_user.

With a fresh ucengine server (using make run), from https://github.com/AF83/ucengine/tree/develop, and with initial datas from demo.sh, I still got that test error, telling that User fetching by name seems to be broken :

elishowk@elsub:~/code/py-ucengine$ python test/basic.py 
..[<UCUser name:document>, <UCUser name:twitter>, <UCUser name:erlyvideo>, <UCUser name:participant2>, <UCUser name:anonymous>, <UCUser name:owner>, <UCUser name:root>, <UCUser name:translation>, <UCUser name:participant3>, <UCUser name:participant>]('GET : ', 404, {u'error': u'not_found'})
409 {u'error': u'conflict'}
# F..
## FAIL: test_modify_user (**main**.TestBasic)

Traceback (most recent call last):
  File "test/basic.py", line 43, in test_modify_user
    session.save(bob)
  File "/home/elishowk/code/py-ucengine/src/ucengine/session.py", line 47, in save
    self._save_user(data)
  File "/home/elishowk/code/py-ucengine/src/ucengine/session.py", line 97, in _save_user
    assert status == 201
AssertionError

---

Ran 5 tests in 0.132s

FAILED (failures=1)
